### PR TITLE
Add compression option

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,10 +106,10 @@ NAME:
 
 USAGE:
    go-bin-deb <cmd> <options>
-   
+
 VERSION:
    0.0.0
-   
+
 COMMANDS:
      generate  Generate the contents of the package
      test      Test the package json file
@@ -130,11 +130,12 @@ USAGE:
    go-bin-deb generate [command options] [arguments...]
 
 OPTIONS:
-   --wd value, -w value      Working directory to prepare the package (default: "pkg-build")
-   --output value, -o value  Output directory for the debian package files
-   --file value, -f value    Path to the deb.json file (default: "deb.json")
-   --version value           Version of the package
-   --arch value, -a value    Arch of the package
+   --wd value, -w value           Working directory to prepare the package (default: "pkg-build")
+   --output value, -o value       Output directory for the debian package files
+   --file value, -f value         Path to the deb.json file (default: "deb.json")
+   --version value                Version of the package
+   --arch value, -a value         Arch of the package
+   --compression value, -z value  Compression to use (via dpkg-deb -Z)
 ```
 
 ### test

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,16 @@
+module github.com/mh-cbon/go-bin-deb
+
+go 1.19
+
+require (
+	github.com/mattn/go-zglob v0.0.0-20160607002833-2dbd7f37a45e
+	github.com/mh-cbon/verbose v0.0.0-20160711150219-2b8e4118ca07
+	github.com/urfave/cli v1.18.0
+)
+
+require (
+	github.com/fatih/color v1.0.0 // indirect
+	github.com/mattn/go-colorable v0.0.5 // indirect
+	github.com/mattn/go-isatty v0.0.0-20151211000621-56b76bdf51f7 // indirect
+	golang.org/x/sys v0.0.0-20160704031755-a408501be4d1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,14 @@
+github.com/fatih/color v1.0.0 h1:4zdNjpoprR9fed2QRCPb2VTPU4UFXEtJc9Vc+sgXkaQ=
+github.com/fatih/color v1.0.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/mattn/go-colorable v0.0.5 h1:X1IeP+MaFWC+vpbhw3y426rQftzXSj+N7eJFnBEMBfE=
+github.com/mattn/go-colorable v0.0.5/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
+github.com/mattn/go-isatty v0.0.0-20151211000621-56b76bdf51f7 h1:owMyzMR4QR+jSdlfkX9jPU3rsby4++j99BfbtgVr6ZY=
+github.com/mattn/go-isatty v0.0.0-20151211000621-56b76bdf51f7/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
+github.com/mattn/go-zglob v0.0.0-20160607002833-2dbd7f37a45e h1:CKUOoFXxmNBWmFTR23znmpAl2WMnDWd/FMjHuSw6mNg=
+github.com/mattn/go-zglob v0.0.0-20160607002833-2dbd7f37a45e/go.mod h1:9fxibJccNxU2cnpIKLRRFA7zX7qhkJIQWBb449FYHOo=
+github.com/mh-cbon/verbose v0.0.0-20160711150219-2b8e4118ca07 h1:TY5IdR1j46GCDiVVfs7Oc9JgpJoA2AmNPRH4oF9cX+g=
+github.com/mh-cbon/verbose v0.0.0-20160711150219-2b8e4118ca07/go.mod h1:oCHJllkeMGmtEJYsuGRMCY0XbgXHyOSZPxKD6O+rHoo=
+github.com/urfave/cli v1.18.0 h1:m9MfmZWX7bwr9kUcs/Asr95j0IVXzGNNc+/5ku2m26Q=
+github.com/urfave/cli v1.18.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
+golang.org/x/sys v0.0.0-20160704031755-a408501be4d1 h1:QtO5ZFD1u7KisZhuRLL2GaZAZDdJqUcTdjFJj8OEePA=
+golang.org/x/sys v0.0.0-20160704031755-a408501be4d1/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/main.go
+++ b/main.go
@@ -53,6 +53,11 @@ func main() {
 					Value: "",
 					Usage: "Arch of the package",
 				},
+				cli.StringFlag{
+					Name:  "compression, z",
+					Value: "",
+					Usage: "Compression to use (via dpkg-deb -Z)",
+				},
 			},
 		},
 		{
@@ -78,6 +83,7 @@ func generateContents(c *cli.Context) error {
 	file := c.String("file")
 	version := c.String("version")
 	arch := c.String("arch")
+	compression := c.String("compression")
 
 	pkgDir := filepath.Join(wd)
 
@@ -104,8 +110,12 @@ func generateContents(c *cli.Context) error {
 		return cli.NewExitError(err.Error(), 1)
 	}
 
-	logger.Printf("Building package in %s to %s", wd, output)
-	if err := buildPackage(pkgDir, output); err != nil {
+	extraArgs := []string{}
+	if compression != "" {
+		extraArgs = append(extraArgs, "-Z"+compression)
+	}
+	logger.Printf("Building package in %s to %s with extra args %v", wd, output, extraArgs)
+	if err := buildPackage(pkgDir, output, extraArgs); err != nil {
 		return cli.NewExitError(err.Error(), 1)
 	}
 
@@ -129,8 +139,12 @@ func testPkg(c *cli.Context) error {
 	return nil
 }
 
-func buildPackage(wd string, output string) error {
-	oCmd := exec.Command("fakeroot", "dpkg-deb", "--build", "debian", output)
+func buildPackage(wd string, output string, extraArgs []string) error {
+	args := []string{"dpkg-deb", "--build", "debian", output}
+	if len(extraArgs) > 0 {
+		args = append(args, extraArgs...)
+	}
+	oCmd := exec.Command("fakeroot", args...)
 	oCmd.Dir = wd
 	oCmd.Stdout = os.Stdout
 	oCmd.Stderr = os.Stderr

--- a/main.go
+++ b/main.go
@@ -140,10 +140,11 @@ func testPkg(c *cli.Context) error {
 }
 
 func buildPackage(wd string, output string, extraArgs []string) error {
-	args := []string{"dpkg-deb", "--build", "debian", output}
+	args := []string{"dpkg-deb"}
 	if len(extraArgs) > 0 {
 		args = append(args, extraArgs...)
 	}
+	args = append(args, "--build", "debian", output)
 	oCmd := exec.Command("fakeroot", args...)
 	oCmd.Dir = wd
 	oCmd.Stdout = os.Stdout


### PR DESCRIPTION
In order to target older operating systems, we need to be able to set the compression to something that they'll support, such as `xz`.  For example, these days, `zstd` is the default, but that won't work on older systems.
    
This option allows you to specify the compression on the command line.  If you do not use the new setting, then the default value from `dpkg-deb` will be used, just the same as before.
